### PR TITLE
Argument checks

### DIFF
--- a/src/BubbleBath.jl
+++ b/src/BubbleBath.jl
@@ -12,7 +12,12 @@ end
     Sphere(pos::NTuple{D,Real}, radius::Real) where D
 Create a `Sphere{D}` object centered at `pos` with radius `radius`.
 """
-Sphere(pos::NTuple{D,Real}, radius::Real) where D = Sphere{D}(Float64.(pos),Float64(radius))
+function Sphere(pos::NTuple{D,Real}, radius::Real) where D
+    if radius ≤ 0
+        throw(ArgumentError("Sphere radius must be a non-negative real number."))
+    end
+    Sphere{D}(Float64.(pos),Float64(radius))
+end
 
 include("bubblebath_algorithm.jl")
 include("packing_fraction.jl")

--- a/src/bubblebath_algorithm.jl
+++ b/src/bubblebath_algorithm.jl
@@ -53,6 +53,10 @@ function generate_radii(
     max_tries = 10000,
     verbose = true
 )::Vector{Float64} where D
+    # allow ϕ_max=1 as a way to fill the box as much as possible
+    if ~(0 < ϕ_max ≤ 1)
+        throw(ArgumentError("Packing fraction should be between 0 and 1."))
+    end
     radii = Float64[]
     V₀ = prod(extent)
     tries = 0
@@ -213,6 +217,11 @@ function bubblebath!(
     max_fails = 100,
     verbose = true
 )::Nothing where D
+    for r in radii
+        if r ≤ 0
+            throw(ArgumentError("Sphere radii must be non-negative real numbers."))
+        end
+    end
     n₀ = length(spheres)
     sizehint!(spheres, length(spheres)+n₀)
     fails = 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,12 +34,19 @@ end
         pos = ntuple(_ -> 5, 3)
         sphere2 = Sphere(pos, radius)
         @test sphere2.pos == sphere.pos
+        # negative radius not allowed
+        @test_throws ArgumentError Sphere((5,5), -1)
     end
 
     @testset "Bubblebath" begin
         L = 10
         extent = ntuple(_ -> L, 3)
         r = 4.0
+        # negative radii not allowed
+        @test_throws ArgumentError bubblebath([-r], extent)
+        # packing fraction must be ϕ∈(0,1]
+        @test_throws ArgumentError bubblebath([r], -0.1, extent)
+        @test_throws ArgumentError bubblebath([r], 1.1, extent)
         bath = bubblebath([r], extent)
         # should be a vector with only one sphere
         @test bath isa Vector{Sphere{3}}


### PR DESCRIPTION
Adds argument checks to `Sphere`, `generate_radii` and `bubblebath!`.

It is not necessary to add checks to every function, since everything falls back on the same instances of `bubblebath!` and `generate_radii`.

Closes #14.