### PR TITLE
Docstring disclaimer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BubbleBath"
 uuid = "06490a66-c478-4593-a275-4b14021bccc5"
 authors = ["Riccardo Foffi <riccardo.foffi@protonmail.com> and contributors"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/bubblebath_algorithm.jl
+++ b/src/bubblebath_algorithm.jl
@@ -14,6 +14,7 @@ The domain is filled with spheres in order of decreasing radius.
 
 ## Keywords
 * `min_distance = 0.0`: Minimum allowed distance between spheres.
+    Negative values can be used to allow overlaps.
 * `through_boundaries = false`: Whether spheres can cross through the domain boundaries.
 * `max_tries = 10000`: Maximum number of insertion tries for each sphere.
     When `max_tries` is reached, the sphere is discarded and the algorithm moves on
@@ -21,6 +22,11 @@ The domain is filled with spheres in order of decreasing radius.
 * `max_fails = 100`: Maximum number of failures (i.e. discarded spheres) allowed.
     Once `max_fails` is reached, the program halts.
 * `verbose = true`: Whether info logs should be printed.
+
+If a negative `min_distance` is used or `through_boundaries` is set to true,
+the packing fraction estimated during the generation will not correspond to the
+real packing fraction of the system.
+In these cases, `ϕ_max` has only a *semi*-quantitative value.
 """
 function bubblebath(
     radius_pdf,

--- a/src/packing_fraction.jl
+++ b/src/packing_fraction.jl
@@ -3,6 +3,8 @@ export packing_fraction
 """
     packing_fraction(spheres::Vector{Sphere{D}}, extent::NTuple{D,Real}) where D
 Evaluate the packing fraction of `spheres` in domain `extent`.
+This measurement is not exact if spheres are overlapping or cross through the
+domain boundaries.
 """
 function packing_fraction(
     spheres::Vector{Sphere{D}},
@@ -31,6 +33,8 @@ volume(sphere::Sphere{3})::Float64 = 4π/3 * sphere.radius^3
     packing_fraction(radii::Vector{Real}, extent::NTuple{D,Real}) where D
 Evaluate the packing fraction of a collection of spheres with radii `radii`
 in domain `extent`.
+This measurement is not exact if spheres are overlapping or cross through the
+domain boundaries.
 """
 function packing_fraction(
     radii::Vector{<:Real},


### PR DESCRIPTION
Adds notice to `bubblebath`, `generate_radii` and `packing_fraction` that current evaluation of packing fraction is not quantitatively exact if sphere overlap or boundary crossing are allowed.